### PR TITLE
Add support for default enum value in a struct or union

### DIFF
--- a/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/TypescriptGenerator.scala
+++ b/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/TypescriptGenerator.scala
@@ -111,6 +111,7 @@ class TypescriptGenerator(
     case MapRHS(elems) => elems
       .map { case (k, v) => s"${constValue(k)}: ${constValue(v)}"}
       .mkString("{", ",", "}")
+    case EnumRHS(enum, value) => s"${enum.sid.toTitleCase.name}.${value.sid.toUpperCase.name}"
     case _ => throw new ScroogeInternalException(s"Unsupported constant type: $rhs")
   }
 

--- a/scrooge-generator-typescript/src/test/resources/school/shared.thrift
+++ b/scrooge-generator-typescript/src/test/resources/school/shared.thrift
@@ -11,6 +11,7 @@ struct Student {
   2: required Age age
   3: optional set<i32> grades = [0, 4]
   5: optional Type type
+  6: required Type secondaryType = Type.ROBOT
 }
 
 enum Type {


### PR DESCRIPTION
## What does this change?
Add support for default enum values in a struct

```thrift
struct MyStruct {
  1: required MyEnum myField = MyEnum.MY_VALUE
}
```