### PR TITLE
Don't import int64 js module if it's not required

### DIFF
--- a/scrooge-generator-typescript/src/main/resources/typescript/imports.mustache
+++ b/scrooge-generator-typescript/src/main/resources/typescript/imports.mustache
@@ -1,3 +1,8 @@
+import {Thrift, TProtocol} from 'thrift';
+{{#needsInt64Import}}
+import Int64 from 'node-int64';
+{{/needsInt64Import}}
+
 {{#imports}}
 import {
 {{#types}}

--- a/scrooge-generator-typescript/src/main/resources/typescript/struct.mustache
+++ b/scrooge-generator-typescript/src/main/resources/typescript/struct.mustache
@@ -1,8 +1,5 @@
 {{>autogen}}
 
-import {Thrift, TProtocol} from 'thrift';
-import Int64 from 'node-int64';
-
 {{> imports}}
 
 export interface {{typeName}} {

--- a/scrooge-generator-typescript/src/main/resources/typescript/union.mustache
+++ b/scrooge-generator-typescript/src/main/resources/typescript/union.mustache
@@ -1,8 +1,5 @@
 {{>autogen}}
 
-import {Thrift, TProtocol} from 'thrift';
-import Int64 from 'node-int64';
-
 {{> imports}}
 
 export type {{typeName}} =

--- a/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/TemplateModels.scala
+++ b/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/TemplateModels.scala
@@ -6,6 +6,7 @@ case class TsStruct(
   fields: Seq[TsField],
   imports: Seq[TsImport],
   defaults: Seq[TsDefaultValue],
+  needsInt64Import: Boolean
 )
 
 trait TsField {

--- a/scrooge-generator-typescript/src/test/resources/decode-encode/tsconfig.json
+++ b/scrooge-generator-typescript/src/test/resources/decode-encode/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true
   }
 }

--- a/scrooge-generator-typescript/src/test/resources/entity/tsconfig.json
+++ b/scrooge-generator-typescript/src/test/resources/entity/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true
   }
 }

--- a/scrooge-generator-typescript/src/test/resources/external/tsconfig.json
+++ b/scrooge-generator-typescript/src/test/resources/external/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true
   }
 }

--- a/scrooge-generator-typescript/src/test/resources/no-int64/noint64.thrift
+++ b/scrooge-generator-typescript/src/test/resources/no-int64/noint64.thrift
@@ -1,0 +1,5 @@
+#@namespace typescript _at_guardian.no_int64
+
+struct NoInt64 {
+  1: optional string someAttribute
+}

--- a/scrooge-generator-typescript/src/test/resources/no-int64/package.json
+++ b/scrooge-generator-typescript/src/test/resources/no-int64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@guardian/school",
+  "version": "0.0.1",
+  "description": "A test package.json",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "typescript": "^3.8.3"
+  },
+  "dependencies": {
+    "@types/node-int64": "^0.4.29",
+    "@types/thrift": "^0.10.9",
+    "node-int64": "^0.4.0",
+    "thrift": "^0.12.0"
+  }
+}

--- a/scrooge-generator-typescript/src/test/resources/no-int64/tsconfig.json
+++ b/scrooge-generator-typescript/src/test/resources/no-int64/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true
+  }
+}

--- a/scrooge-generator-typescript/src/test/resources/school/tsconfig.json
+++ b/scrooge-generator-typescript/src/test/resources/school/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true
   }
 }

--- a/scrooge-generator-typescript/src/test/resources/school/university.thrift
+++ b/scrooge-generator-typescript/src/test/resources/school/university.thrift
@@ -9,4 +9,5 @@ struct School {
   5: required list<set<list<shared.Student>>> crazyNestedList
   6: required map<string,shared.Student> classes
   10: required map<i32,shared.Student> otherMapOfPeople
+  11: optional i64 ageInMs
 }

--- a/scrooge-generator-typescript/src/test/resources/schoolWithExternal/tsconfig.json
+++ b/scrooge-generator-typescript/src/test/resources/schoolWithExternal/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true
   }
 }

--- a/scrooge-generator-typescript/src/test/scala/com/gu/scrooge/backend/typescript/TypescriptGeneratorSpec.scala
+++ b/scrooge-generator-typescript/src/test/scala/com/gu/scrooge/backend/typescript/TypescriptGeneratorSpec.scala
@@ -14,6 +14,8 @@ import org.apache.thrift.transport.TMemoryBuffer
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.io.Source
+
 class TypescriptGeneratorSpec extends AnyFlatSpec with Matchers {
 
   def findFile(name: String): Path = Paths.get(this.getClass.getClassLoader.getResource(name).toURI)
@@ -90,6 +92,7 @@ class TypescriptGeneratorSpec extends AnyFlatSpec with Matchers {
   val schoolWithExternalProject: NpmProject = forProject("@guardian/schoolWithExternal", "schoolWithExternal")
   val decodeEncodeProject: NpmProject = forProject("@guardian/decode-encode", "decode-encode")
   val entityProject: NpmProject = forProject("@guardian/content-entity-model", "entity")
+  val noInt64Project: NpmProject = forProject("@guardian/no-int64", "no-int64")
 
   val school: School = {
     val harry: Student = Student(FullName("Harry Potter"), 10, Set(0), Some(Human))
@@ -164,6 +167,16 @@ class TypescriptGeneratorSpec extends AnyFlatSpec with Matchers {
 
   it should "compile the typescript of the school with external dependency project" in {
     compile(schoolWithExternalProject)
+  }
+
+  it should "generate and compile typescript without the int64 import if there's no int64 used in the file" in {
+    generate(noInt64Project, Seq("noint64.thrift"))
+    compile(noInt64Project)
+    val generatedFile = noInt64Project.packageDirectory.resolve("noInt64.ts").toFile
+
+    generatedFile.exists shouldBe true
+    val source = Source.fromFile(generatedFile)
+    source.mkString.contains("import Int64 from 'node-int64';") shouldBe false
   }
 
 }


### PR DESCRIPTION
This imports the int64 module only if it's required. 

This is so that strict compilation will not raise an error on that import.
