### PR TITLE
Don't add int64 for child structs

### DIFF
--- a/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/TypescriptGenerator.scala
+++ b/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/TypescriptGenerator.scala
@@ -214,8 +214,6 @@ class TypescriptGenerator(
 
   def needsInt64Import(ft: Seq[FieldType]): Boolean = ft.exists {
     case TI64 => true
-    case struct: StructType => needsInt64Import(struct.struct.fields.map(_.fieldType))
-    case _: EnumType => false
     case listType: ListType => needsInt64Import(Seq(listType.eltType))
     case setType: SetType => needsInt64Import(Seq(setType.eltType))
     case mapType: MapType => needsInt64Import(Seq(mapType.keyType, mapType.valueType))

--- a/scrooge-generator-typescript/src/test/resources/no-int64/noint64.thrift
+++ b/scrooge-generator-typescript/src/test/resources/no-int64/noint64.thrift
@@ -2,4 +2,9 @@
 
 struct NoInt64 {
   1: optional string someAttribute
+  2: required YesInt64 itsATrap
+}
+
+struct YesInt64 {
+  1: required i64 someLargeNumber
 }


### PR DESCRIPTION
It turns out my logic was a bit too generous as I was checking if any attribute of any nested struct had an int64. That's not required as the logic to deserialize and serialize nested structs is delegated to their respective companion object

I've added a test case to ensure it did fail, then fixed it.
