### PR TITLE
Ensure the typescript compiler doesn't recursively search for types.

### DIFF
--- a/sbt-scrooge-typescript/src/main/scala/com/gu/thrift/ScroogeTypescriptGen.scala
+++ b/sbt-scrooge-typescript/src/main/scala/com/gu/thrift/ScroogeTypescriptGen.scala
@@ -91,7 +91,10 @@ object ScroogeTypescriptGen extends AutoPlugin {
           |    "strict": true,
           |    "esModuleInterop": true,
           |    "forceConsistentCasingInFileNames": true,
-          |    "declaration": true
+          |    "declaration": true,
+          |    // this is to disable searching in ../node_modules as it can trigger compilation errors unrelated to this
+          |    // self contained project
+          |    "typeRoots": ["./node_modules/@types"],
           |  }
           |}
           |""".stripMargin


### PR DESCRIPTION
The default behaviour of typescript is to recursively search for types in the `node_modules/@types` directory, then its parent `../node_modules/@types` and its parent `../../node_modules/@types` and so on and so forth.

This is probably fine in most cases but if you project is within a sub-directory of another project it can lead to very strange behaviours. I'm therefore disabling that search as thrift generated projects will be self contained anyway.
