### PR TITLE
Fix Handling Of Empty Collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target
 
 .idea
+
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "scrooge-extras",
+  "version": "1.2.6",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "typescript": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "scrooge-extras",
+  "version": "1.2.6",
+  "description": "An SBT plugin to generate typescript definitions from thrift files.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/guardian/scrooge-extras.git"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/guardian/scrooge-extras/issues"
+  },
+  "homepage": "https://github.com/guardian/scrooge-extras#readme",
+  "devDependencies": {
+    "typescript": "^4.1.5"
+  }
+}

--- a/scrooge-generator-typescript/src/main/resources/typescript/read_field.mustache
+++ b/scrooge-generator-typescript/src/main/resources/typescript/read_field.mustache
@@ -15,10 +15,8 @@ if (listInfo{{depth}}.etype === {{nestedType.thriftType}}) {
         {{/nestedType}}
         {{variableName}}.push({{nestedType.variableName}});
     }
-    protocol.{{endReadingStatement}}();
-} else {
-    protocol.skip(ftype);
 }
+protocol.{{endReadingStatement}}();
 {{/isCollection}}
 {{#isMap}}
 const mapInfo{{depth}} = protocol.readMapBegin();
@@ -34,8 +32,6 @@ if (mapInfo{{depth}}.ktype === {{keyType.thriftType}} && mapInfo{{depth}}.vtype 
     {{/valueType}}
     {{variableName}}[{{keyType.variableName}}] = {{valueType.variableName}};
     }
-    protocol.readMapEnd();
-} else {
-    protocol.skip(ftype);
 }
+protocol.readMapEnd();
 {{/isMap}}

--- a/scrooge-generator-typescript/src/test/resources/school/university.thrift
+++ b/scrooge-generator-typescript/src/test/resources/school/university.thrift
@@ -10,4 +10,6 @@ struct School {
   6: required map<string,shared.Student> classes
   10: required map<i32,shared.Student> otherMapOfPeople
   11: optional i64 ageInMs
+  12: optional map<string,i32> emptyMap
+  13: optional list<string> emptyList
 }

--- a/scrooge-generator-typescript/src/test/scala/com/gu/scrooge/backend/typescript/TypescriptGeneratorSpec.scala
+++ b/scrooge-generator-typescript/src/test/scala/com/gu/scrooge/backend/typescript/TypescriptGeneratorSpec.scala
@@ -101,7 +101,9 @@ class TypescriptGeneratorSpec extends AnyFlatSpec with Matchers {
       schoolName = Some("Hogwarts School of Witchcraft and Wizardry"),
       students = Seq(harry, hermione),
       crazyNestedList = Seq(Set(Seq(harry), Seq(hermione))),
-      classes = Map("Magic" -> harry)
+      classes = Map("Magic" -> harry),
+      emptyMap = Some(Map.empty),
+      emptyList = Some(List.empty)
     )
   }
 

--- a/scrooge-generator-typescript/src/test/scala/com/gu/scrooge/backend/typescript/TypescriptGeneratorSpec.scala
+++ b/scrooge-generator-typescript/src/test/scala/com/gu/scrooge/backend/typescript/TypescriptGeneratorSpec.scala
@@ -58,7 +58,7 @@ class TypescriptGeneratorSpec extends AnyFlatSpec with Matchers {
     val npmInstall = Process("npm install", npmProject.packageDirectory.toFile).!
     npmInstall shouldEqual 0
 
-    val tsc = Process("tsc", npmProject.packageDirectory.toFile).!
+    val tsc = Process("./node_modules/.bin/tsc", npmProject.packageDirectory.toFile).!
     tsc shouldEqual 0
   }
 


### PR DESCRIPTION
## What does this change?

Paired with @alexduf on this work.

**TL;DR** It fixes a bug where the parser would incorrectly read the end of a given collection input, which caused problems attempting to parse empty collections.

### Background

Thrift is a binary protocol. Decoders operate by working their way through a buffer of binary data and attempting to parse that into language-specific data types.

The bug we discovered exists in the code generated to read `struct`s. The code generated by this project goes through a common process to read each field in the struct.

1. It reads the preamble for each field to figure out what type and id (number) it is
2. It checks that the type matches the expected type for the field with that id
3. Depending on whether the type matches:
    1. If yes, it reads the amount of data from the buffer corresponding to the expected type
    2. If no, it skips over that field

The bug existed when step 3 was applied for collections. When parsing a collection you need to:

1. Parse the start of the collection
2. Parse the entries within the collection
3. Parse the end of the collection

We discovered the issue for collections where the content didn't match the type that was expected, either because the collection was **empty** (in which case Thrift doesn't provide a type for the content) or because the type simply **didn't match** (e.g. `list<string>` rather than `list<i32>`). In these situations the parsing code would perform step 1, discover that the content types didn't match, and proceed _to skip an amount of data equivalent to the collection size_. There are two problems with this approach: a) it doesn't parse the end of the collection, and b) it may skip the wrong amount of data because the start of the collection has already been parsed and because it doesn't know how much data the collection contains.

The fix for the **empty collection** issue is to _always_ parse the end of a collection, and not attempt to skip it, once we have parsed the start. That is what this PR addresses. We're going to do a follow-up to address the **type mismatch** problem.

**Note:** We've also added TypeScript as a dev dependency. Previously the tests assumed a globally installed copy of `tsc`, which isn't always available.

## Changes

- Added `package.json` and `package-lock.json` to make TypeScript a dev dependency
- Updated tests to use locally installed version of tsc
- Ignored `node_modules`
- Update read_field templates to always read collections/maps to end
- Added test cases for empty maps and empty lists

## How to test

Use it against some data with empty collections. You can also run the tests that we've added.

## How can we measure success?

It's able to parse empty collections in future.
