### PR TITLE
Move to Sonatype releasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ You need the following installed and configured:
 _Assuming your project is already set up with scrooge to generate scala files_
 
 In `project/plugins.sbt`
+TODO: figure out instructions if/when it is available from Sonatype
 ```sbt
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
 

--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ lazy val standardReleaseSteps: Seq[ReleaseStep] = Seq(
 
 lazy val sbtScroogeTypescript = project.in(file("sbt-scrooge-typescript"))
   .dependsOn(typescript)
+  .settings(mavenSettings)
   .settings(
     name := "sbt-scrooge-typescript",
     sbtPlugin := true,
@@ -81,6 +82,7 @@ lazy val sbtScroogeTypescript = project.in(file("sbt-scrooge-typescript"))
   )
 
 lazy val typescript = project.in(file("scrooge-generator-typescript"))
+  .settings(mavenSettings)
   .settings(
     name := "scrooge-generator-typescript",
     organization := "com.gu",

--- a/build.sbt
+++ b/build.sbt
@@ -58,8 +58,8 @@ lazy val standardReleaseSteps: Seq[ReleaseStep] = Seq(
   releaseStepCommandAndRemaining("+publishSigned"),
   releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
-  commitNextVersion,
-  pushChanges
+  commitNextVersion //,
+  // pushChanges    // <-- only to main branch
 )
 
 lazy val sbtScroogeTypescript = project.in(file("sbt-scrooge-typescript"))

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,40 @@ publish / skip := true
 
 val scroogeVersion = "20.4.1"
 
-val standardReleaseSteps: Seq[ReleaseStep] = Seq(
+lazy val mavenSettings = Seq(
+  pomExtra := (
+    <url>https://github.com/guardian/scrooge-extras</url>
+      <scm>
+        <connection>scm:git:git@github.com:guardian/scrooge-extras.git</connection>
+        <developerConnection>scm:git:git@github.com:guardian/scrooge-extras.git</developerConnection>
+        <url>git@github.com:guardian/scrooge-extras.git</url>
+      </scm>
+      <developers>
+        <developer>
+          <id>alexduf</id>
+          <name>Alex Dufournet</name>
+          <url>https://github.com/alexduf</url>
+        </developer>
+        <developer>
+          <id>JamieB-gu</id>
+          <name>Jamie B</name>
+          <url>https://github.com/JamieB-gu</url>
+        </developer>
+        <developer>
+          <id>JustinPinner</id>
+          <name>Justin Pinner</name>
+          <url>https://github.com/JustinPinner</url>
+        </developer>
+      </developers>
+    ),
+  publishTo := sonatypePublishToBundle.value,
+  publishConfiguration := publishConfiguration.value.withOverwrite(false),
+  publishMavenStyle := true,
+  publishArtifact in Test := false,
+  pomIncludeRepository := { _ => false }
+)
+
+lazy val standardReleaseSteps: Seq[ReleaseStep] = Seq(
   checkSnapshotDependencies,
   inquireVersions,
   runClean,
@@ -22,7 +55,8 @@ val standardReleaseSteps: Seq[ReleaseStep] = Seq(
   commitReleaseVersion,
   tagRelease,
   publishArtifacts,
-  releaseStepTask(bintrayRelease),
+  releaseStepCommandAndRemaining("+publishSigned"),
+  releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
   commitNextVersion,
   pushChanges
@@ -33,8 +67,8 @@ lazy val sbtScroogeTypescript = project.in(file("sbt-scrooge-typescript"))
   .settings(
     name := "sbt-scrooge-typescript",
     sbtPlugin := true,
-    bintrayOrganization := Some("guardian"),
-    bintrayRepository := "sbt-plugins",
+    organization := "com.gu",
+    resolvers += Resolver.sonatypeRepo("public"),
     releasePublishArtifactsAction := PgpKeys.publishSigned.value,
 
     // this plugin depends on the scrooge plugin
@@ -49,8 +83,8 @@ lazy val sbtScroogeTypescript = project.in(file("sbt-scrooge-typescript"))
 lazy val typescript = project.in(file("scrooge-generator-typescript"))
   .settings(
     name := "scrooge-generator-typescript",
-    bintrayOrganization := Some("guardian"),
-    bintrayRepository := "platforms",
+    organization := "com.gu",
+    resolvers += Resolver.sonatypeRepo("public"),
     libraryDependencies ++= Seq(
       "com.twitter" %% "scrooge-generator" % scroogeVersion,
       "com.twitter" %% "scrooge-core" % scroogeVersion % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,13 @@ val scroogeVersion = "20.4.1"
 lazy val mavenSettings = Seq(
   pomExtra := (
     <url>https://github.com/guardian/scrooge-extras</url>
+      <licenses>
+        <license>
+          <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
       <scm>
         <connection>scm:git:git@github.com:guardian/scrooge-extras.git</connection>
         <developerConnection>scm:git:git@github.com:guardian/scrooge-extras.git</developerConnection>

--- a/build.sbt
+++ b/build.sbt
@@ -58,8 +58,8 @@ lazy val standardReleaseSteps: Seq[ReleaseStep] = Seq(
   releaseStepCommandAndRemaining("+publishSigned"),
   releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
-  commitNextVersion //,
-  // pushChanges    // <-- only to main branch
+  commitNextVersion,
+  pushChanges
 )
 
 lazy val sbtScroogeTypescript = project.in(file("sbt-scrooge-typescript"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,7 @@
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
-
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
-
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 
 // to generate scala classes for tests only
 libraryDependencies += "com.twitter" %% "scrooge-generator" % "20.4.1"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.7-SNAPSHOT"
+version in ThisBuild := "1.2.7-RC2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.7-SNAPSHOT"
+version in ThisBuild := "1.2.7-RC1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.7-RC1"
+version in ThisBuild := "1.2.7-SNAPSHOT"


### PR DESCRIPTION
## What does this change?
Stops releasing to bintray and uses Sonatype (and ultimately Maven?) instead. Don't know if this will work. Cribbed it from content-api-models, and may need additional setting up in the repos. Let's see what happens / what others think?  🤞

## How to test
Try to release the thing!

## How can we measure success?
Did we release it to Sonatype (and Maven)? Success!

## Have we considered potential risks?
It could all go horribly wrong. But worst case? It won't release.

## Images
N/A

## Accessibility
N/A