### PR TITLE
Move to Sonatype releasing - Take 2 

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ In `project/plugins.sbt`
 ```sbt
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
 
-resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
 addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "<latest_version>")
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import sbt.Defaults.sbtPluginExtra
 import sbtrelease.ReleaseStateTransformations._
 import com.twitter.scrooge.Compiler
+import sbt.url
 
 name := "scrooge-extras"
 
@@ -8,12 +9,9 @@ ThisBuild / organization := "com.gu"
 ThisBuild / scalaVersion := "2.12.11"
 ThisBuild / licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
-// don't publish the root project
-publish / skip := true
-
 val scroogeVersion = "20.4.1"
 
-val standardReleaseSteps: Seq[ReleaseStep] = Seq(
+lazy val standardReleaseSteps: Seq[ReleaseStep] = Seq(
   checkSnapshotDependencies,
   inquireVersions,
   runClean,
@@ -22,19 +20,38 @@ val standardReleaseSteps: Seq[ReleaseStep] = Seq(
   commitReleaseVersion,
   tagRelease,
   publishArtifacts,
-  releaseStepTask(bintrayRelease),
+  releaseStepCommandAndRemaining("+publishSigned"),
+  releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
   commitNextVersion,
   pushChanges
 )
 
+lazy val commonSettings = Seq(
+  organization := "com.gu",
+  publishTo := sonatypePublishToBundle.value,
+  scmInfo := Some(ScmInfo(
+    url("https://github.com/guardian/scrooge-extras"),
+    "scm:git:git@github.com:guardian/scrooge-extras.git"
+  )),
+  licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
+  homepage := Some(url("https://github.com/guardian/scrooge-extras")),
+  developers := List(Developer(
+    id = "Guardian",
+    name = "Guardian",
+    email = null,
+    url = url("https://github.com/guardian")
+  )),
+  resolvers += Resolver.sonatypeRepo("public"),
+  releaseProcess := standardReleaseSteps
+)
+
 lazy val sbtScroogeTypescript = project.in(file("sbt-scrooge-typescript"))
   .dependsOn(typescript)
+  .settings(commonSettings)
   .settings(
     name := "sbt-scrooge-typescript",
     sbtPlugin := true,
-    bintrayOrganization := Some("guardian"),
-    bintrayRepository := "sbt-plugins",
     releasePublishArtifactsAction := PgpKeys.publishSigned.value,
 
     // this plugin depends on the scrooge plugin
@@ -42,15 +59,13 @@ lazy val sbtScroogeTypescript = project.in(file("sbt-scrooge-typescript"))
       "com.twitter" % "scrooge-sbt-plugin" % scroogeVersion,
       (pluginCrossBuild / sbtBinaryVersion).value,
       (update / scalaBinaryVersion).value
-    ),
-    releaseProcess := standardReleaseSteps
+    )
   )
 
 lazy val typescript = project.in(file("scrooge-generator-typescript"))
+  .settings(commonSettings)
   .settings(
     name := "scrooge-generator-typescript",
-    bintrayOrganization := Some("guardian"),
-    bintrayRepository := "platforms",
     libraryDependencies ++= Seq(
       "com.twitter" %% "scrooge-generator" % scroogeVersion,
       "com.twitter" %% "scrooge-core" % scroogeVersion % "test",
@@ -64,7 +79,12 @@ lazy val typescript = project.in(file("scrooge-generator-typescript"))
       compiler.language = "scala"
       compiler.run()
       ((Compile / sourceManaged).value / "generated" ** "*.scala").get()
-    },
-    releaseProcess := standardReleaseSteps
+    }
   )
 
+lazy val root = Project(id = "root", base = file("."))
+  .aggregate(sbtScroogeTypescript, typescript)
+  .settings(commonSettings)
+  .settings(
+    publishArtifact := false
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,6 @@ lazy val commonSettings = Seq(
     url("https://github.com/guardian/scrooge-extras"),
     "scm:git:git@github.com:guardian/scrooge-extras.git"
   )),
-  licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
   homepage := Some(url("https://github.com/guardian/scrooge-extras")),
   developers := List(Developer(
     id = "Guardian",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,6 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
-
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
-
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 
 // to generate scala classes for tests only
 libraryDependencies += "com.twitter" %% "scrooge-generator" % "20.4.1"


### PR DESCRIPTION
## What does this change?
Changes made in the initial [Move to Sonatype releasing PR](https://github.com/guardian/scrooge-extras/pull/16) successfully compiled our assets locally but didn't result in anything actually being uploaded to Sonatype or Maven.

@davidfurey jumped in to help out and we've arrived at this version. ~There's a caveat insofar as the `sbt-scrooge-typescript` project still doesn't appear to be going anywhere, so this is still a WIP while we try to figure that out.~

We completed a couple of release candidate releases to maven and tested importing those outputs into other applications, both of which appeared to resolve the sbt plugin successfully.

## How to test
Do it for real (release a prod version)

## How can we measure success?
If we're able to release both projects and consume them _somewhere_, that's a win.

## Have we considered potential risks?
We can't build content-api-models (and other dependent codebases) until this is working

## Images
N/A

## Accessibility
N/A
