### PR TITLE
Bump TypeScript Package Thrift Version To 0.13.0

### DIFF
--- a/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/NPMLibraries.scala
+++ b/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/NPMLibraries.scala
@@ -3,9 +3,9 @@ package com.gu.scrooge.backend.typescript
 object NPMLibraries {
   val dependencies = Map(
     "@types/node-int64" -> "^0.4.29",
-    "@types/thrift" -> "^0.10.9",
+    "@types/thrift" -> "^0.10.10",
     "node-int64" -> "^0.4.0",
-    "thrift" -> "^0.12.0"
+    "thrift" -> "^0.13.0"
   )
 
   val devDependencies = Map("typescript" -> "^3.8.3")


### PR DESCRIPTION
## Why?

Updates TS projects generated using `scrooge-extras` to use a more recent version of the Thrift npm package.

## Changes

- Bumped thrift types to `0.10.10`
- Bumped Thrift in built project to `0.13.0`
