### PR TITLE
Revisiting sbt version bump to 1.5.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 
 .idea
+.bsp
 
 node_modules

--- a/README.md
+++ b/README.md
@@ -218,3 +218,23 @@ Any contribution should ensure the tests are running, in the sbt shell:
 ```sbtshell
 test
 ```
+
+## How to release this library
+
+Beta releases from a WIP branch can be deployed Maven. To do this, start sbt with
+
+`sbt -DRELEASE_TYPE=beta`
+
+In beta mode, when you follow the remaining instructions, you'll be prompted to confirm that you intend to put out a
+beta release and if so, the version number should take the form of `x.y.z.beta.n`. While making beta releases you 
+should always update the next version to reflect the beta status of the code when prompted, i.e. don't just let it 
+revert to -SNAPSHOT which it will want to do by default. 
+
+When making a prod release once your changes have been through the PR process and are merged to the main/master branch, 
+checkout the main/master branch and start sbt as normal (without the -DRELEASE_TYPE parameter) and run
+
+```sbtshell
+release cross
+```
+
+Following a successful production release, the version details are automatically committed and pushed back to github.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Here are some settings you may want to use:
  - scroogeTypescriptDevDependencies: The dev dependencies to put in the `package.json`
  - scroogeTypescriptDependencies: The dependencies to put in the `package.json`
  - scroogeTypescriptDryRun: To be able to run everything without publishing to NPM
+ - scroogeTypescriptPublishTag: An optional tag for your NPM release, primarily for beta.
  
  
 ## Using the generated files

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
 import sbt.Defaults.sbtPluginExtra
-import sbtrelease.ReleaseStateTransformations._
+import sbtrelease.ReleaseStateTransformations.{setReleaseVersion, _}
 import com.twitter.scrooge.Compiler
 import sbt.url
+import sbtrelease.{Version, versionFormatError}
 
 name := "scrooge-extras"
 
@@ -11,21 +12,71 @@ ThisBuild / licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICEN
 
 val scroogeVersion = "20.4.1"
 
-lazy val standardReleaseSteps: Seq[ReleaseStep] = Seq(
-  checkSnapshotDependencies,
-  inquireVersions,
-  runClean,
-  runTest,
-  setReleaseVersion,
-  commitReleaseVersion,
-  tagRelease,
-  publishArtifacts,
-  releaseStepCommandAndRemaining("+publishSigned"),
-  releaseStepCommand("sonatypeBundleRelease"),
-  setNextVersion,
-  commitNextVersion,
-  pushChanges
-)
+val candidateReleaseType = "candidate"
+val candidateReleaseSuffix = "-RC1"
+
+lazy val versionSettingsMaybe = {
+  // For a non-prod release, start sbt with e.g. sbt -DRELEASE_TYPE=candidate
+  // For a production release, just start sbt without that
+  sys.props.get("RELEASE_TYPE").map {
+    case v if v == candidateReleaseType => candidateReleaseSuffix
+  }.map { suffix =>
+    releaseVersion := {
+      ver => Version(ver).map(_.withoutQualifier.string).map(_.concat(suffix)).getOrElse(versionFormatError(ver))
+    }
+  }.toSeq
+}
+
+lazy val checkReleaseType: ReleaseStep = ReleaseStep({ st: State =>
+  val releaseType = sys.props.get("RELEASE_TYPE").map {
+    case v if v == candidateReleaseType => candidateReleaseType.toUpperCase
+  }.getOrElse("PRODUCTION")
+
+  SimpleReader.readLine(s"This will be a $releaseType release. Continue? (y/n) [N]: ") match {
+    case Some(v) if Seq("Y", "YES").contains(v.toUpperCase) => // we don't care about the value - it's a flow control mechanism
+    case _ => sys.error(s"Release aborted by user!")
+  }
+  // we haven't changed state, just pass it on if we haven't thrown an error from above
+  st
+})
+
+lazy val releaseProcessSteps: Seq[ReleaseStep] = {
+  val commonSteps = Seq(
+    checkReleaseType,
+    checkSnapshotDependencies,
+    inquireVersions,
+    runClean,
+    runTest,
+    setReleaseVersion
+  )
+
+  // prodSteps will take effect if sbt was started without any -DRELEASE_TYPE param
+  lazy val prodSteps: Seq[ReleaseStep] = Seq(
+    commitReleaseVersion,
+    tagRelease,
+    publishArtifacts,
+    releaseStepCommandAndRemaining("+publishSigned"),
+    releaseStepCommand("sonatypeBundleRelease"),
+    setNextVersion,
+    commitNextVersion,
+    pushChanges
+  )
+
+  // candidateSteps will take effect if sbt was started with -DRELEASE_TYPE=candidate
+  lazy val candidateSteps: Seq[ReleaseStep] = Seq(
+    publishArtifacts,
+    releaseStepCommandAndRemaining("+publishSigned"),
+    releaseStepCommand("sonatypeBundleRelease"),
+    setNextVersion
+  )
+
+  // detect if a RELEASE_TYPE param was specified when sbt was started, and choose release type based on that
+  commonSteps ++ (sys.props.get("RELEASE_TYPE") match {
+    case Some(v) if v == candidateReleaseType => candidateSteps // this is a release candidate build to sonatype and Maven
+    case _ => prodSteps  // it's a production release
+  })
+
+}
 
 lazy val commonSettings = Seq(
   organization := "com.gu",
@@ -42,7 +93,7 @@ lazy val commonSettings = Seq(
     url = url("https://github.com/guardian")
   )),
   resolvers += Resolver.sonatypeRepo("public"),
-  releaseProcess := standardReleaseSteps
+  releaseProcess := releaseProcessSteps
 )
 
 lazy val sbtScroogeTypescript = project.in(file("sbt-scrooge-typescript"))
@@ -83,7 +134,7 @@ lazy val typescript = project.in(file("scrooge-generator-typescript"))
 
 lazy val root = Project(id = "root", base = file("."))
   .aggregate(sbtScroogeTypescript, typescript)
-  .settings(commonSettings)
+  .settings(commonSettings, versionSettingsMaybe)
   .settings(
     publishArtifact := false
   )

--- a/build.sbt
+++ b/build.sbt
@@ -10,16 +10,16 @@ ThisBuild / organization := "com.gu"
 ThisBuild / scalaVersion := "2.12.11"
 ThisBuild / licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
-val scroogeVersion = "21.12.0"
+val scroogeVersion = "22.1.0"   // remember to also update plugins.sbt if this version changes
 
-val candidateReleaseType = "candidate"
-val candidateReleaseSuffix = "-RC1"
+val betaReleaseType = "beta"
+val betaReleaseSuffix = ".beta.0"
 
 lazy val versionSettingsMaybe = {
-  // For a non-prod release, start sbt with e.g. sbt -DRELEASE_TYPE=candidate
+  // For a beta release, start sbt with sbt -DRELEASE_TYPE=beta
   // For a production release, just start sbt without that
   sys.props.get("RELEASE_TYPE").map {
-    case v if v == candidateReleaseType => candidateReleaseSuffix
+    case v if v == betaReleaseType => betaReleaseSuffix
   }.map { suffix =>
     releaseVersion := {
       ver => Version(ver).map(_.withoutQualifier.string).map(_.concat(suffix)).getOrElse(versionFormatError(ver))
@@ -29,7 +29,7 @@ lazy val versionSettingsMaybe = {
 
 lazy val checkReleaseType: ReleaseStep = ReleaseStep({ st: State =>
   val releaseType = sys.props.get("RELEASE_TYPE").map {
-    case v if v == candidateReleaseType => candidateReleaseType.toUpperCase
+    case v if v == betaReleaseType => betaReleaseType.toUpperCase
   }.getOrElse("PRODUCTION")
 
   SimpleReader.readLine(s"This will be a $releaseType release. Continue? (y/n) [N]: ") match {
@@ -62,8 +62,8 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
     pushChanges
   )
 
-  // candidateSteps will take effect if sbt was started with -DRELEASE_TYPE=candidate
-  lazy val candidateSteps: Seq[ReleaseStep] = Seq(
+  // betaSteps will take effect if sbt was started with -DRELEASE_TYPE=beta
+  lazy val betaSteps: Seq[ReleaseStep] = Seq(
     publishArtifacts,
     releaseStepCommandAndRemaining("+publishSigned"),
     releaseStepCommand("sonatypeBundleRelease"),
@@ -72,7 +72,7 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
 
   // detect if a RELEASE_TYPE param was specified when sbt was started, and choose release type based on that
   commonSteps ++ (sys.props.get("RELEASE_TYPE") match {
-    case Some(v) if v == candidateReleaseType => candidateSteps // this is a release candidate build to sonatype and Maven
+    case Some(v) if v == betaReleaseType => betaSteps // this is a beta build to sonatype and Maven
     case _ => prodSteps  // it's a production release
   })
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ ThisBuild / licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICEN
 val scroogeVersion = "22.1.0"   // remember to also update plugins.sbt if this version changes
 
 val betaReleaseType = "beta"
-val betaReleaseSuffix = ".beta.0"
+val betaReleaseSuffix = "-beta.0"
 
 lazy val versionSettingsMaybe = {
   // For a beta release, start sbt with sbt -DRELEASE_TYPE=beta

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import sbt.Defaults.sbtPluginExtra
 import sbtrelease.ReleaseStateTransformations.{setReleaseVersion, _}
-import com.twitter.scrooge.Compiler
+import com.twitter.scrooge.{ScroogeConfig, Compiler}
 import sbt.url
 import sbtrelease.{Version, versionFormatError}
 
@@ -10,7 +10,7 @@ ThisBuild / organization := "com.gu"
 ThisBuild / scalaVersion := "2.12.11"
 ThisBuild / licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
-val scroogeVersion = "20.4.1"
+val scroogeVersion = "21.12.0"
 
 val candidateReleaseType = "candidate"
 val candidateReleaseSuffix = "-RC1"
@@ -123,10 +123,12 @@ lazy val typescript = project.in(file("scrooge-generator-typescript"))
       "org.scalatest" %% "scalatest" % "3.1.1" % "test"
     ),
     Test / sourceGenerators += { () =>
-      val compiler = new Compiler()
-      compiler.destFolder = ((Compile / sourceManaged).value / "generated").getAbsolutePath
-      compiler.thriftFiles ++= ((Test / resourceDirectory).value / "school" ** "*.thrift").get().map(_.getAbsolutePath)
-      compiler.language = "scala"
+      val scroogeConfig = ScroogeConfig(
+        destFolder = ((Compile / sourceManaged).value / "generated").getAbsolutePath,
+        thriftFiles = ((Test / resourceDirectory).value / "school" ** "*.thrift").get().map(_.getAbsolutePath).toList,
+        language = "scala"
+      )
+      val compiler = new Compiler(scroogeConfig)
       compiler.run()
       ((Compile / sourceManaged).value / "generated" ** "*.scala").get()
     }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.10
+sbt.version = 1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 
 // to generate scala classes for tests only
-libraryDependencies += "com.twitter" %% "scrooge-generator" % "21.12.0"
+libraryDependencies += "com.twitter" %% "scrooge-generator" % "22.1.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 
 // to generate scala classes for tests only
-libraryDependencies += "com.twitter" %% "scrooge-generator" % "20.4.1"
+libraryDependencies += "com.twitter" %% "scrooge-generator" % "21.12.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,8 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 
 // to generate scala classes for tests only
 libraryDependencies += "com.twitter" %% "scrooge-generator" % "22.1.0"

--- a/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/NPMLibraries.scala
+++ b/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/NPMLibraries.scala
@@ -3,10 +3,10 @@ package com.gu.scrooge.backend.typescript
 object NPMLibraries {
   val dependencies = Map(
     "@types/node-int64" -> "^0.4.29",
-    "@types/thrift" -> "^0.10.10",
+    "@types/thrift" -> "^0.10.11",
     "node-int64" -> "^0.4.0",
-    "thrift" -> "^0.13.0"
+    "thrift" -> "^0.15.0"
   )
 
-  val devDependencies = Map("typescript" -> "^3.8.3")
+  val devDependencies = Map("typescript" -> "^4.5.4")
 }

--- a/scrooge-generator-typescript/src/test/scala/com/gu/scrooge/backend/typescript/TypescriptGeneratorSpec.scala
+++ b/scrooge-generator-typescript/src/test/scala/com/gu/scrooge/backend/typescript/TypescriptGeneratorSpec.scala
@@ -1,14 +1,13 @@
 package com.gu.scrooge.backend.typescript
 
 import java.nio.file.{Files, Path, Paths, StandardCopyOption}
-
 import com.gu.thriftTest.school.School
 import com.gu.thriftTest.school.common.Denomination.FullName
 import com.gu.thriftTest.school.common.Type.{Human, Robot}
 import com.gu.thriftTest.school.common.{Denomination, Student}
 
 import sys.process._
-import com.twitter.scrooge.{Compiler, ThriftStruct, ThriftUtil}
+import com.twitter.scrooge.{Compiler, ScroogeConfig, ThriftStruct, ThriftUtil}
 import org.apache.thrift.protocol.{TCompactProtocol, TProtocol}
 import org.apache.thrift.transport.TMemoryBuffer
 import org.scalatest.flatspec.AnyFlatSpec
@@ -63,13 +62,15 @@ class TypescriptGeneratorSpec extends AnyFlatSpec with Matchers {
   }
 
   def generate(npmProject: NpmProject, thriftFiles: Seq[String]): Unit = {
-    val compiler = new Compiler()
-    compiler.destFolder = npmProject.output.toString
-    thriftFiles.foreach(thriftFile => {
-      compiler.thriftFiles += npmProject.resources.resolve(thriftFile).toString
-    })
-    compiler.defaultNamespace = npmProject.packageName
-    compiler.language = "typescript"
+    val scroogeConfig = ScroogeConfig(
+      destFolder = npmProject.output.toString,
+      thriftFiles = thriftFiles.map (thriftFile => {
+        npmProject.resources.resolve(thriftFile).toString
+      }).toList,
+      defaultNamespace = npmProject.packageName,
+      language = "typescript"
+    )
+    val compiler = new Compiler(scroogeConfig)
     compiler.run()
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.1-SNAPSHOT"
+ThisBuild / version := "1.4.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.4.1-SNAPSHOT"
+ThisBuild / version := "1.5.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.6.0.beta.2"
+version in ThisBuild := "1.6.0-beta.5"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.6.0-beta.5"
+ThisBuild / version := "1.6.0-beta.6"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.6.0-beta.6"
+ThisBuild / version := "1.6.0-beta.7"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.5.0-SNAPSHOT"
+version in ThisBuild := "1.6.0.beta.2"


### PR DESCRIPTION
## What does this change?

Whilst the primary ambition of this PR is to upgrade various dependencies, it has also been an opportunity to enable the building of beta releases of the sbt plugin for testing.

In doing so we discovered that when this code is used to make npm releases, and those are themselves to be considered beta versions, we needed to supply a `--tag beta` to the npm release process, so that is implemented as a new `scroogeTypescriptPublishTag` setting which technically can be anything useful for consumers of the resulting npm libraries, but will likely be used most frequently to differentiate test and production-ready releases.

## How to test

We used this branch to build
[scrooge-generator-typescript 1.6.0-beta.4](https://mvnrepository.com/artifact/com.gu/scrooge-generator-typescript_2.12/1.6.0-beta.4)
[sbt-scrooge-typescript 1.6.0-beta.4](https://ossindex.sonatype.org/component/pkg:maven/com.gu/sbt-scrooge-typescript@1.6.0-beta.4)

Then, with the above `sbt-scrooge-typescript` build of the sbt plugin we built the beta versions of `content-entity-model` as described on https://github.com/guardian/content-entity/pull/17

## How can we measure success?

The aim is to reduce, by updating dependencies, reliance on older libraries that have newer versions available, and where those updates _may_ introduce breaking changes, do so in a way to make it clear that we are testing that potential.

## Have we considered potential risks?

Consumers of this code will likely have to choose whether to adopt the changed versions or not, so we don't expect to break anything as a result of doing this.

## Images

N/A

## Accessibility

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
- [x] Not applicable
