### PR TITLE
feat: run `tsc` from generated package's `node_modules` instead of global installation

### DIFF
--- a/sbt-scrooge-typescript/src/main/scala/com/gu/thrift/ScroogeTypescriptGen.scala
+++ b/sbt-scrooge-typescript/src/main/scala/com/gu/thrift/ScroogeTypescriptGen.scala
@@ -149,7 +149,7 @@ object ScroogeTypescriptGen extends AutoPlugin {
 
       runCmd("npm install", packageDir, logger = logger, onError = "Unable to install npm dependencies")
 
-      runCmd("npm run tsc", packageDir, logger = logger, onError = "There are compilation errors, check the output above")
+      runCmd("npx tsc", packageDir, logger = logger, onError = "There are compilation errors, check the output above")
 
       val compiledFiles = (packageDir ** "*.js").get()
 

--- a/sbt-scrooge-typescript/src/main/scala/com/gu/thrift/ScroogeTypescriptGen.scala
+++ b/sbt-scrooge-typescript/src/main/scala/com/gu/thrift/ScroogeTypescriptGen.scala
@@ -149,7 +149,7 @@ object ScroogeTypescriptGen extends AutoPlugin {
 
       runCmd("npm install", packageDir, logger = logger, onError = "Unable to install npm dependencies")
 
-      runCmd("tsc", packageDir, logger = logger, onError = "There are compilation errors, check the output above")
+      runCmd("npm run tsc", packageDir, logger = logger, onError = "There are compilation errors, check the output above")
 
       val compiledFiles = (packageDir ** "*.js").get()
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.6.1-SNAPSHOT"
+ThisBuild / version := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

- Runs `tsc` with [`npm run`](https://docs.npmjs.com/cli/v8/commands/npm-run-script).  This uses the `tsc` installed in the package directory's `node_modules`
- Previously, the build process was using a global installation of `tsc` which can cause version mismatches and problems in CI pipelines

## How to test

- Release a snapshot package
- I'm unsure if there's a good way to test this locally

## Have we considered potential risks?

- It's possible this change isn't backwards compatible, but that risk can be mitigated with testing and if necessary a major version bump
