### PR TITLE
Followed the steps to add gh-scala release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions: { contents: write, pull-requests: write }
+    secrets:
+      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}

--- a/build.sbt
+++ b/build.sbt
@@ -2,81 +2,17 @@ import sbt.Defaults.sbtPluginExtra
 import sbtrelease.ReleaseStateTransformations.{setReleaseVersion, _}
 import com.twitter.scrooge.{ScroogeConfig, Compiler}
 import sbt.url
-import sbtrelease.{Version, versionFormatError}
+import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 name := "scrooge-extras"
 
 ThisBuild / organization := "com.gu"
 ThisBuild / scalaVersion := "2.12.17"
-ThisBuild / licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+ThisBuild / licenses := Seq(License.Apache2)
 
-val scroogeVersion = "22.7.0"   // remember to also update plugins.sbt if this version changes
+ThisBuild / scalacOptions := Seq("-release:11")
 
-val betaReleaseType = "beta"
-val betaReleaseSuffix = "-beta.0"
-
-lazy val versionSettingsMaybe = {
-  // For a beta release, start sbt with sbt -DRELEASE_TYPE=beta
-  // For a production release, just start sbt without that
-  sys.props.get("RELEASE_TYPE").map {
-    case v if v == betaReleaseType => betaReleaseSuffix
-  }.map { suffix =>
-    releaseVersion := {
-      ver => Version(ver).map(_.withoutQualifier.string).map(_.concat(suffix)).getOrElse(versionFormatError(ver))
-    }
-  }.toSeq
-}
-
-lazy val checkReleaseType: ReleaseStep = ReleaseStep({ st: State =>
-  val releaseType = sys.props.get("RELEASE_TYPE").map {
-    case v if v == betaReleaseType => betaReleaseType.toUpperCase
-  }.getOrElse("PRODUCTION")
-
-  SimpleReader.readLine(s"This will be a $releaseType release. Continue? (y/n) [N]: ") match {
-    case Some(v) if Seq("Y", "YES").contains(v.toUpperCase) => // we don't care about the value - it's a flow control mechanism
-    case _ => sys.error(s"Release aborted by user!")
-  }
-  // we haven't changed state, just pass it on if we haven't thrown an error from above
-  st
-})
-
-lazy val releaseProcessSteps: Seq[ReleaseStep] = {
-  val commonSteps = Seq(
-    checkReleaseType,
-    checkSnapshotDependencies,
-    inquireVersions,
-    runClean,
-    runTest,
-    setReleaseVersion
-  )
-
-  // prodSteps will take effect if sbt was started without any -DRELEASE_TYPE param
-  lazy val prodSteps: Seq[ReleaseStep] = Seq(
-    commitReleaseVersion,
-    tagRelease,
-    publishArtifacts,
-    releaseStepCommandAndRemaining("+publishSigned"),
-    releaseStepCommand("sonatypeBundleRelease"),
-    setNextVersion,
-    commitNextVersion,
-    pushChanges
-  )
-
-  // betaSteps will take effect if sbt was started with -DRELEASE_TYPE=beta
-  lazy val betaSteps: Seq[ReleaseStep] = Seq(
-    publishArtifacts,
-    releaseStepCommandAndRemaining("+publishSigned"),
-    releaseStepCommand("sonatypeBundleRelease"),
-    setNextVersion
-  )
-
-  // detect if a RELEASE_TYPE param was specified when sbt was started, and choose release type based on that
-  commonSteps ++ (sys.props.get("RELEASE_TYPE") match {
-    case Some(v) if v == betaReleaseType => betaSteps // this is a beta build to sonatype and Maven
-    case _ => prodSteps  // it's a production release
-  })
-
-}
+val scroogeVersion = "22.7.0" // remember to also update plugins.sbt if this version changes
 
 lazy val commonSettings = Seq(
   organization := "com.gu",
@@ -94,8 +30,7 @@ lazy val commonSettings = Seq(
     email = null,
     url = url("https://github.com/guardian")
   )),
-  resolvers ++= Resolver.sonatypeOssRepos("public"),
-  releaseProcess := releaseProcessSteps
+  resolvers ++= Resolver.sonatypeOssRepos("public")
 )
 
 lazy val sbtScroogeTypescript = project.in(file("sbt-scrooge-typescript"))
@@ -104,7 +39,6 @@ lazy val sbtScroogeTypescript = project.in(file("sbt-scrooge-typescript"))
   .settings(
     name := "sbt-scrooge-typescript",
     sbtPlugin := true,
-    releasePublishArtifactsAction := PgpKeys.publishSigned.value,
 
     // this plugin depends on the scrooge plugin
     libraryDependencies += sbtPluginExtra(
@@ -141,7 +75,19 @@ lazy val typescript = project.in(file("scrooge-generator-typescript"))
 
 lazy val root = Project(id = "root", base = file("."))
   .aggregate(sbtScroogeTypescript, typescript)
-  .settings(commonSettings, versionSettingsMaybe)
+  .settings(commonSettings)
   .settings(
-    publishArtifact := false
+    publish / skip := true,
+    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+    releaseProcess := Seq(
+      checkSnapshotDependencies,
+      inquireVersions,
+      runClean,
+      runTest,
+      setReleaseVersion,
+      commitReleaseVersion,
+      tagRelease,
+      setNextVersion,
+      commitNextVersion
+    )
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.7.2
+sbt.version = 1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,10 @@
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")
 
 // to generate scala classes for tests only
 libraryDependencies += "com.twitter" %% "scrooge-generator" % "22.7.0"
+
+


### PR DESCRIPTION
ref: https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/configuration.md

Note that CI is currently failing on this PR (because CI is failing on `main`, see #31 ) but _are_ passing on #28 (which performs a Typescript upgrade that somehow fixes the tests).