### PR TITLE
Add CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+on:
+  workflow_dispatch:
+  pull_request:
+
+  # triggering CI default branch improves caching
+  # see https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: 11
+          cache: sbt
+      - name: Build and Test
+        run: sbt -v +test
+      - uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()  #runs even if there is a test failure
+        with:
+          files: test-results/**/TEST-*.xml

--- a/build.sbt
+++ b/build.sbt
@@ -80,6 +80,8 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
 
 lazy val commonSettings = Seq(
   organization := "com.gu",
+  Test / testOptions +=
+    Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}", "-o"),
   publishTo := sonatypePublishToBundle.value,
   scmInfo := Some(ScmInfo(
     url("https://github.com/guardian/scrooge-extras"),


### PR DESCRIPTION
Currently, running `sbt test` on the `main` branch fails, and so we see that here with this PR in the CI results!

Having CI is obviously [good](https://github.com/guardian/recommendations/blob/main/continuous-integration.md) in general, but also this should help with evaluating #28 (which appears to actually _fix_ the tests, at least locally) and #30, which adds automated release support with [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow).

I think it would be best to merge this PR first, then rebase #28 on top to see it fix the tests.