### PR TITLE
Update typescript version in test projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ target
 .bsp
 
 node_modules
+
+.bloop/
+.metals/
+project/
+test-results/

--- a/scrooge-generator-typescript/src/test/resources/decode-encode/decode-encode.ts
+++ b/scrooge-generator-typescript/src/test/resources/decode-encode/decode-encode.ts
@@ -41,7 +41,11 @@ async function decode(buffer: Buffer): Promise<School> {
 async function encode(school: School): Promise<Buffer> {
     return new Promise((resolve, reject) => {
         const outputBufferTransport = new TBufferedTransport(undefined, (buffer, seqId) => {
-            resolve(buffer);
+            if (buffer !== undefined) {
+                resolve(buffer);
+            } else {
+                reject();
+            }
         });
         const outputProtocol = new TCompactProtocol(outputBufferTransport);
         SchoolSerde.write(outputProtocol, school);

--- a/scrooge-generator-typescript/src/test/resources/decode-encode/package.json
+++ b/scrooge-generator-typescript/src/test/resources/decode-encode/package.json
@@ -4,7 +4,7 @@
   "description": "A test package.json",
   "license": "Apache-2.0",
   "devDependencies": {
-    "typescript": "^3.8.3"
+    "typescript": "^4.1.5"
   },
   "dependencies": {
     "@guardian/school": "file:../school",

--- a/scrooge-generator-typescript/src/test/resources/entity/package.json
+++ b/scrooge-generator-typescript/src/test/resources/entity/package.json
@@ -4,7 +4,7 @@
   "description": "A test package.json",
   "license": "Apache-2.0",
   "devDependencies": {
-    "typescript": "^3.8.3"
+    "typescript": "^4.1.5"
   },
   "dependencies": {
     "@types/node-int64": "^0.4.29",

--- a/scrooge-generator-typescript/src/test/resources/external/package.json
+++ b/scrooge-generator-typescript/src/test/resources/external/package.json
@@ -4,7 +4,7 @@
   "description": "A test package.json",
   "license": "Apache-2.0",
   "devDependencies": {
-    "typescript": "^3.8.3"
+    "typescript": "^4.1.5"
   },
   "dependencies": {
     "@types/node-int64": "^0.4.29",

--- a/scrooge-generator-typescript/src/test/resources/no-int64/package.json
+++ b/scrooge-generator-typescript/src/test/resources/no-int64/package.json
@@ -4,7 +4,7 @@
   "description": "A test package.json",
   "license": "Apache-2.0",
   "devDependencies": {
-    "typescript": "^3.8.3"
+    "typescript": "^4.1.5"
   },
   "dependencies": {
     "@types/node-int64": "^0.4.29",

--- a/scrooge-generator-typescript/src/test/resources/school/package.json
+++ b/scrooge-generator-typescript/src/test/resources/school/package.json
@@ -4,7 +4,7 @@
   "description": "A test package.json",
   "license": "Apache-2.0",
   "devDependencies": {
-    "typescript": "^3.8.3"
+    "typescript": "^4.1.5"
   },
   "dependencies": {
     "@types/node-int64": "^0.4.29",

--- a/scrooge-generator-typescript/src/test/resources/schoolWithExternal/package.json
+++ b/scrooge-generator-typescript/src/test/resources/schoolWithExternal/package.json
@@ -4,10 +4,10 @@
   "description": "A test package.json",
   "license": "Apache-2.0",
   "devDependencies": {
-    "typescript": "^3.8.3"
+    "typescript": "^4.1.5"
   },
   "dependencies": {
-    "@guardian/external":  "file:../external",
+    "@guardian/external": "file:../external",
     "@types/node-int64": "^0.4.29",
     "@types/thrift": "^0.10.9",
     "node-int64": "^0.4.0",


### PR DESCRIPTION
## What does this change?

- Bumps TypeScript version in each test project's `package.json`. This fixes tests run with `sbt test`