### PR TITLE
Fix release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,20 +224,5 @@ test
 
 ## How to release this library
 
-Beta releases from a WIP branch can be deployed Maven. To do this, start sbt with
-
-`sbt -DRELEASE_TYPE=beta`
-
-In beta mode, when you follow the remaining instructions, you'll be prompted to confirm that you intend to put out a
-beta release and if so, the version number should take the form of `x.y.z.beta.n`. While making beta releases you 
-should always update the next version to reflect the beta status of the code when prompted, i.e. don't just let it 
-revert to -SNAPSHOT which it will want to do by default. 
-
-When making a prod release once your changes have been through the PR process and are merged to the main/master branch, 
-checkout the main/master branch and start sbt as normal (without the -DRELEASE_TYPE parameter) and run
-
-```sbtshell
-release cross
-```
-
-Following a successful production release, the version details are automatically committed and pushed back to github.
+Releases are done using gha-scala-library-release-workflow release process.
+The details are here: https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md

--- a/build.sbt
+++ b/build.sbt
@@ -7,35 +7,23 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 name := "scrooge-extras"
 
 ThisBuild / organization := "com.gu"
-ThisBuild / scalaVersion := "2.12.17"
+ThisBuild / scalaVersion := "2.12.18"
 ThisBuild / licenses := Seq(License.Apache2)
 
 ThisBuild / scalacOptions := Seq("-release:11")
 
 val scroogeVersion = "22.7.0" // remember to also update plugins.sbt if this version changes
 
-lazy val commonSettings = Seq(
+lazy val artifactProductionSettings = Seq(
   organization := "com.gu",
   Test / testOptions +=
     Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}", "-o"),
-  publishTo := sonatypePublishToBundle.value,
-  scmInfo := Some(ScmInfo(
-    url("https://github.com/guardian/scrooge-extras"),
-    "scm:git:git@github.com:guardian/scrooge-extras.git"
-  )),
-  homepage := Some(url("https://github.com/guardian/scrooge-extras")),
-  developers := List(Developer(
-    id = "Guardian",
-    name = "Guardian",
-    email = null,
-    url = url("https://github.com/guardian")
-  )),
   resolvers ++= Resolver.sonatypeOssRepos("public")
 )
 
 lazy val sbtScroogeTypescript = project.in(file("sbt-scrooge-typescript"))
   .dependsOn(typescript)
-  .settings(commonSettings)
+  .settings(artifactProductionSettings)
   .settings(
     name := "sbt-scrooge-typescript",
     sbtPlugin := true,
@@ -49,7 +37,7 @@ lazy val sbtScroogeTypescript = project.in(file("sbt-scrooge-typescript"))
   )
 
 lazy val typescript = project.in(file("scrooge-generator-typescript"))
-  .settings(commonSettings)
+  .settings(artifactProductionSettings)
   .settings(
     name := "scrooge-generator-typescript",
     libraryDependencies ++= Seq(
@@ -75,7 +63,6 @@ lazy val typescript = project.in(file("scrooge-generator-typescript"))
 
 lazy val root = Project(id = "root", base = file("."))
   .aggregate(sbtScroogeTypescript, typescript)
-  .settings(commonSettings)
   .settings(
     publish / skip := true,
     releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,


### PR DESCRIPTION
## What does this change?

Some of settings that are not required under gha-scala-workflow release process has been removed - these additional settings broke the release process, as can be seen here:

https://github.com/guardian/scrooge-extras/actions/runs/7573680653/job/20626419324

![image](https://github.com/guardian/scrooge-extras/assets/52038/b90f401d-4b8d-4625-87b0-9190bdb8ecf0)


Readme release description updated.

## How to test

Make a release once the PR is reviewed and merged.

## How can we measure success?

release process should run smoothly.
