### PR TITLE
Temporarily disable compatibility testing as last release failed...

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,6 @@ lazy val root = Project(id = "root", base = file("."))
   .aggregate(sbtScroogeTypescript, typescript)
   .settings(
     publish / skip := true,
-    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseProcess := Seq(
       checkSnapshotDependencies,
       inquireVersions,


### PR DESCRIPTION
...and did not produce any artifacts to be compared against, so our latest release run failed:

https://github.com/guardian/scrooge-extras/actions/runs/7574075570/job/20627669330#step:4:51

Release 3.0.1 never occurred, but the compatibility testing code is looking for it:
```
[error]   not found: https://repo1.maven.org/maven2/com/gu/scrooge-generator-typescript_2.12/3.0.1/scrooge-generator-typescript_2.12-3.0.1.pom
```
