### PR TITLE
Update the hard-coded Thrift typescript dependencies

### DIFF
--- a/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/NPMLibraries.scala
+++ b/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/NPMLibraries.scala
@@ -3,9 +3,9 @@ package com.gu.scrooge.backend.typescript
 object NPMLibraries {
   val dependencies = Map(
     "@types/node-int64" -> "^0.4.29",
-    "@types/thrift" -> "^0.10.11",
+    "@types/thrift" -> "^0.10.17",
     "node-int64" -> "^0.4.0",
-    "thrift" -> "^0.15.0"
+    "thrift" -> "^0.20.0"
   )
 
   val devDependencies = Map("typescript" -> "^4.5.4")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the outdated thrift 0.15.0 dependency to the most recent (Apr 2024) 0.20.0

## How to test

Build a library reliant on this and build an app reliant on that library. 
