### PR TITLE
Downgrade scrooge

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ ThisBuild / licenses := Seq(License.Apache2)
 
 ThisBuild / scalacOptions := Seq("-release:11")
 
-val scroogeVersion = "22.7.0" // remember to also update plugins.sbt if this version changes
+val scroogeVersion = "22.1.0" // remember to also update plugins.sbt if this version changes
 
 lazy val artifactProductionSettings = Seq(
   organization := "com.gu",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
 
 // to generate scala classes for tests only
-libraryDependencies += "com.twitter" %% "scrooge-generator" % "22.7.0"
+libraryDependencies += "com.twitter" %% "scrooge-generator" % "22.1.0"


### PR DESCRIPTION
Scrooge 22.2.0 brought in a breaking change where reserved keywords in Thrift were strictly enforced (https://twitter.github.io/scrooge/changelog.html#id13)

This causes issues downstream in content-api-models which uses the reserved keyword 'end' (https://github.com/guardian/content-api-models/blob/main/models/src/main/thrift/content/v1.thrift#L399-L400).

The long-term solution is to rename the 'end' field to 'endDate' (see https://github.com/guardian/content-api/issues/2903), but in the short term we need to unblock the release of the apps-rendering-api-models library, which is currently failing. Releasing this library will allow us to support the new Subtitles asset type in DCR (https://github.com/guardian/dotcom-rendering/pull/14533).

### Testing
✅  If this works, it should unblock the NPM release of apps-rendering-api-models: https://github.com/guardian/apps-rendering-api-models/pull/106
✅ And unblock downstream consumption by DCR: https://github.com/guardian/dotcom-rendering/pull/14533