### PR TITLE
Bump Typescript compilation version

### DIFF
--- a/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/NPMLibraries.scala
+++ b/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/NPMLibraries.scala
@@ -8,5 +8,5 @@ object NPMLibraries {
     "thrift" -> "^0.15.0"
   )
 
-  val devDependencies = Map("typescript" -> "^4.5.4")
+  val devDependencies = Map("typescript" -> "5.9.3")
 }


### PR DESCRIPTION
## What does this change?

In #42 we bumped the TS version in various places, including our tests, to allow CI to pass. 

This worked, but there was one other place we missed out which is the version used downstream when using `scrooge-extras` to compile Thrift into TS. 

This meant that actually using `scrooge-extras` to compile and publish to NPM was failing when consumed downstream (https://github.com/guardian/apps-rendering-api-models/actions/runs/18165055968).

## How to test

✅ If this works, it should unblock the NPM release of apps-rendering-api-models: https://github.com/guardian/apps-rendering-api-models/pull/106, via https://github.com/guardian/scrooge-extras/pull/39.