### PR TITLE
Update tsconfig.json target from es5 to es6

### DIFF
--- a/sbt-scrooge-typescript/src/main/scala/com/gu/thrift/ScroogeTypescriptGen.scala
+++ b/sbt-scrooge-typescript/src/main/scala/com/gu/thrift/ScroogeTypescriptGen.scala
@@ -149,6 +149,8 @@ object ScroogeTypescriptGen extends AutoPlugin {
 
       runCmd("npm install", packageDir, logger = logger, onError = "Unable to install npm dependencies")
 
+      runCmd("npx tsc -v", packageDir, logger = logger, onError = "Unable to print the TypeScript version, check if tsc is correctly installed")
+
       runCmd("npx tsc", packageDir, logger = logger, onError = "There are compilation errors, check the output above")
 
       val compiledFiles = (packageDir ** "*.js").get()

--- a/sbt-scrooge-typescript/src/main/scala/com/gu/thrift/ScroogeTypescriptGen.scala
+++ b/sbt-scrooge-typescript/src/main/scala/com/gu/thrift/ScroogeTypescriptGen.scala
@@ -90,7 +90,7 @@ object ScroogeTypescriptGen extends AutoPlugin {
         """
           |{
           |  "compilerOptions": {
-          |    "target": "es5",
+          |    "target": "es6",
           |    "module": "commonjs",
           |    "strict": true,
           |    "esModuleInterop": true,

--- a/scrooge-generator-typescript/src/test/resources/decode-encode/tsconfig.json
+++ b/scrooge-generator-typescript/src/test/resources/decode-encode/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/scrooge-generator-typescript/src/test/resources/entity/tsconfig.json
+++ b/scrooge-generator-typescript/src/test/resources/entity/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/scrooge-generator-typescript/src/test/resources/external/tsconfig.json
+++ b/scrooge-generator-typescript/src/test/resources/external/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/scrooge-generator-typescript/src/test/resources/no-int64/tsconfig.json
+++ b/scrooge-generator-typescript/src/test/resources/no-int64/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/scrooge-generator-typescript/src/test/resources/school/tsconfig.json
+++ b/scrooge-generator-typescript/src/test/resources/school/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/scrooge-generator-typescript/src/test/resources/schoolWithExternal/tsconfig.json
+++ b/scrooge-generator-typescript/src/test/resources/schoolWithExternal/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Co-authored-by: Ravi <7014230+arelra@users.noreply.github.com>
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Update tsconfig.json target from ES5 to ES6

The NPM publish step on [https://github.com/guardian/content-atom/](https://github.com/guardian/content-atom) which runs the plugin `ScroogeTypescriptGen` (created by this repo) is failing running `tsc` as using a target of `es5` is now deprecated.

The error on `content-atom` is due to a mismatch between installed TypeScript versions. `content-atom` is using an old version of `scrooge-extras` which incorrectly uses the global installed TypeScript version, which when TypeScript v6 was released causes an ES5 deprecation error.

```bash
[info] Running tsc
Error: tsconfig.json(4,15): error TS5107: Option 'target=ES5' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
[error] java.lang.Exception: Return code: 2. There are compilation errors, check the output above
```

The correct selection of TypeScript was fixed (many years ago) here: https://github.com/guardian/scrooge-extras/pull/25

However `content-atom` is still on an old version with this bug:
https://github.com/guardian/content-atom/blob/869adebb7869ab5a0bd8998c8f1c74e95b71a79f/project/plugins.sbt#L5

`content-api-models` was fixed by upgrading to the latest version of `sbt-scrooge-typescript`:
https://github.com/guardian/content-api-models/pull/299

`content-atom` is fixed by also upgrading:
https://github.com/guardian/content-atom/pull/213

We are updating the target module version here to ensure that this does not break when we move to TypeScript v6 in future.