### PR TITLE
Update thrift and @types/thrift to latest

### DIFF
--- a/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/NPMLibraries.scala
+++ b/scrooge-generator-typescript/src/main/scala/com/gu/scrooge/backend/typescript/NPMLibraries.scala
@@ -3,9 +3,9 @@ package com.gu.scrooge.backend.typescript
 object NPMLibraries {
   val dependencies = Map(
     "@types/node-int64" -> "^0.4.29",
-    "@types/thrift" -> "^0.10.11",
+    "@types/thrift" -> "0.10.17",
     "node-int64" -> "^0.4.0",
-    "thrift" -> "^0.15.0"
+    "thrift" -> "0.23.0"
   )
 
   val devDependencies = Map("typescript" -> "5.9.3")


### PR DESCRIPTION
## What does this change?

content-api-models uses this project to generate an npm package, which some of our apps (e.g. teleporter) depend on. Currently there’re security alerts against the version of thrift this introduces (0.15.0), which I’d like to resolve. (E.g. this alert on teleporter: https://github.com/guardian/teleporter/security/dependabot/49 )

To do this, this PR updates the added npm dependency to the latest version of thrift, which is high enough to dismiss the vulnerability alert.

## How has this change been tested?

Tested via https://github.com/guardian/content-api-models/pull/318 and https://github.com/guardian/teleporter/pull/170.